### PR TITLE
Convert Cache to write-back, write-allocate.

### DIFF
--- a/VCPU/CPU/Cache.h
+++ b/VCPU/CPU/Cache.h
@@ -9,9 +9,77 @@
 #include "Register.h"
 #include "Decoder.h"
 #include "MultiGate.h"
+#include "Masker.h"
 #include "MuxBundle.h"
 #include "CacheLine.h"
 #include "Memory.h"
+
+
+class ByteMask : public Component
+{
+public:
+	typedef Bundle<32> Word;
+	void Connect(const Bundle<2> byteindex, const Wire& bytewrite, const Wire& halfwrite, const Wire& wordwrite)
+	{
+		bytemasker.Connect({ Word(0xffU), Word(0xff00U), Word(0xff0000U), Word(0xff000000U) },	byteindex);
+		halfmasker.Connect({ Word(0xffffU), Word(0xffff0000U) }, byteindex[1]);
+		masker.Connect({ Word::ON, bytemasker.Out(), halfmasker.Out(), Word::ON },	{ &bytewrite, &halfwrite });
+		write.Connect(masker.Out(), Word(wordwrite));
+	}
+	void Update()
+	{
+		bytemasker.Update();
+		halfmasker.Update();
+		masker.Update();
+		write.Update();
+	}
+	const Word& Mask() const { return write.Out(); }
+
+private:
+	MuxBundle<32, 4> bytemasker;
+	MuxBundle<32, 2> halfmasker;
+	MuxBundle<32, 4> masker;
+	MultiGate<AndGate, 32> write;
+};
+
+template <unsigned int N>
+class CacheLineMasker : public Component
+{
+public:
+	typedef Bundle<N> CacheLine;
+	void Connect(const Bundle<2> byteindex, const Bundle<bits(N)-5> wordoffset, const Bundle<32>& dataword, const CacheLine& dataline,
+		const Wire& bytewrite, const Wire& halfwrite, const Wire& wordwrite)
+	{
+		mask.Connect(byteindex, bytewrite, halfwrite, wordwrite);
+		wordShifter.Connect(dataword, byteindex.ShiftZeroExtend<5>(3));
+		maskedDataWord.Connect(wordShifter.Out(), mask.Mask());
+		lineDataShifter.Connect(maskedDataWord.Out().ZeroExtend<N>(), wordoffset.ShiftZeroExtend<bits(N)>(5));
+		lineMaskShifter.Connect(mask.Mask().ZeroExtend<N>(), wordoffset.ShiftZeroExtend<bits(N)>(5));
+		maskedCacheLine.Connect(lineDataShifter.Out(), dataline, lineMaskShifter.Out());
+	}
+	void Update()
+	{
+		mask.Update();
+		wordShifter.Update();
+		maskedDataWord.Update();
+		lineDataShifter.Update();
+		lineMaskShifter.Update();
+		maskedCacheLine.Update();
+	}
+	const Bundle<32>& Word() const { return maskedDataWord.Out(); }
+	const CacheLine& Line() const { return maskedCacheLine.Out(); }
+
+private:
+	ByteMask mask;
+	LeftShifter<32> wordShifter;
+	MultiGate<AndGate, 32> maskedDataWord;
+	LeftShifter<N> lineDataShifter;
+	LeftShifter<N> lineMaskShifter;
+	Masker<N> maskedCacheLine;
+};
+
+
+
 
 template <unsigned int CACHE_SIZE_BYTES, unsigned int CACHE_LINE_BITS, unsigned int MAIN_MEMORY_BYTES = 2048>
 class Cache : public Component
@@ -22,6 +90,7 @@ public:
 	static const int MEMORY_BYTES = MAIN_MEMORY_BYTES;
 
 	static const int WORD_BYTES = WORD_SIZE / 8;
+	static const int BYTE_INDEX_BITS = bits(WORD_BYTES);
 	static const int ADDR_BITS = bits(MAIN_MEMORY_BYTES);
 	static const int MAIN_MEMORY_LINES = MAIN_MEMORY_BYTES * 8 / CACHE_LINE_BITS;
 	static const int NUM_CACHE_LINES = CACHE_SIZE_BYTES * 8 / CACHE_LINE_BITS;
@@ -51,6 +120,17 @@ public:
 	const Wire& NoStall() { return needStallInv.Out(); }
 
 private:
+	class CacheAddrBundle : public AddrBundle
+	{
+	public:
+		using AddrBundle::AddrBundle;
+		Bundle<BYTE_INDEX_BITS> ByteIndex() { return Range<BYTE_INDEX_BITS>(0); }
+		Bundle<ADDR_BITS - BYTE_INDEX_BITS> WordIndex() { return Range<ADDR_BITS - BYTE_INDEX_BITS>(BYTE_INDEX_BITS); }
+		CacheOffsetBundle WordOffsetInLine() { return WordIndex().Range<CACHE_OFFSET_BITS>(0); }
+		CacheIndexBundle CacheLineIndex() { return WordIndex().Range<CACHE_INDEX_BITS>(CACHE_OFFSET_BITS); }
+		TagBundle Tag() { return WordIndex().Range<TAG_BITS>(CACHE_OFFSET_BITS + CACHE_INDEX_BITS);}
+	};
+
 	typename MemoryType::ReqBuffer buffer;
 	MemoryType mMemory;
 	std::array<CacheLine<WORD_SIZE, CACHE_WORDS, TAG_BITS>, NUM_CACHE_LINES> cachelines;
@@ -59,10 +139,8 @@ private:
 	AndGateN<3> gotResultFromMemory;
 	Decoder<NUM_CACHE_LINES> indexDecoder;
 
-	MuxBundle<WORD_SIZE, 4> bytemasker;
-	MuxBundle<WORD_SIZE, 2> halfmasker;
-	MuxBundle<WORD_SIZE, 4> masker;
-	LeftShifter<WORD_SIZE> dataByteShifter;
+	ByteMask masker;
+	CacheLineMasker<CACHE_LINE_BITS> dataShifter;
 
 	Multiplexer<NUM_CACHE_LINES> cacheHitMux;
 	Inverter cacheMiss;
@@ -82,7 +160,7 @@ private:
 	int cycles;
 
 #ifdef DEBUG
-	AddrBundle DEBUG_addr;
+	CacheAddrBundle DEBUG_addr;
 #endif
 
 	friend class Debugger;
@@ -108,37 +186,32 @@ inline Cache<CACHE_SIZE_BYTES, CACHE_LINE_BITS, MAIN_MEMORY_BYTES>::~Cache()
 
 template <unsigned int CACHE_SIZE_BYTES, unsigned int CACHE_LINE_BITS, unsigned int MAIN_MEMORY_BYTES>
 void Cache<CACHE_SIZE_BYTES, CACHE_LINE_BITS, MAIN_MEMORY_BYTES>::Connect(const AddrBundle& addr, const DataBundle& data, const Wire& read,
-	const Wire& write, const Wire& bytewrite, const Wire& halfwrite)
+																			const Wire& write, const Wire& bytewrite, const Wire& halfwrite)
 {
+	CacheAddrBundle address;
+	address.Connect(0,addr);
 #ifdef DEBUG
-	DEBUG_addr.Connect(0, addr);
+	DEBUG_addr.Connect(0, address);
 #endif
 	buffer.Connect(addr, data, write, read);
 	mMemory.Connect(buffer);
 
-	auto byteAddr = addr.Range<bits(WORD_BYTES)>(0);
-	auto wordAddr = addr.Range<ADDR_BITS - bits(WORD_BYTES)>(bits(WORD_BYTES));
-
-	CacheOffsetBundle offset = wordAddr.Range<CACHE_OFFSET_BITS>(0);
-	CacheIndexBundle index = wordAddr.Range<CACHE_INDEX_BITS>(CACHE_OFFSET_BITS);
-	TagBundle tag = wordAddr.Range<TAG_BITS>(CACHE_OFFSET_BITS + CACHE_INDEX_BITS);
+	CacheIndexBundle index = address.CacheLineIndex();
 
 	addrReadMatcher.Connect(addr, mMemory.ReadAddr());
 	gotResultFromMemory.Connect({ &addrReadMatcher.Out(), &cacheMiss.Out(), &mMemory.ServicedRead() });
 	indexDecoder.Connect(index, gotResultFromMemory.Out());
 
-	bytemasker.Connect({ Bundle<WORD_SIZE>(0xff), Bundle<WORD_SIZE>(0xff00), Bundle<WORD_SIZE>(0xff0000), Bundle<WORD_SIZE>(0xff0000) }, byteAddr);
-	halfmasker.Connect({ Bundle<WORD_SIZE>(0xffff), Bundle<WORD_SIZE>(0xffff0000) }, byteAddr[1]);
-	masker.Connect({ Bundle<WORD_SIZE>::ON, bytemasker.Out(), halfmasker.Out(), Bundle<WORD_SIZE>::ON }, { &bytewrite, &halfwrite });
-
-	dataByteShifter.Connect(data, { &Wire::OFF, &Wire::OFF, &Wire::OFF, &byteAddr[0], &byteAddr[1] });
+	masker.Connect(address.ByteIndex(), bytewrite, halfwrite, write);
+	//dataShifter.Connect(address.ByteIndex(), data, address.WordOffsetInLine());
 
 	std::array<Bundle<CACHE_LINE_BITS>, NUM_CACHE_LINES> cacheLineDataOuts;
 	Bundle<NUM_CACHE_LINES> cacheHitCollector;
 
 	for (int i = 0; i < NUM_CACHE_LINES; ++i)
 	{
-		cachelines[i].Connect(tag, offset, masker.Out(), dataByteShifter.Out(), indexDecoder.Out()[i], mMemory.OutLine());
+		cachelines[i].Connect(address.Tag(), address.WordOffsetInLine(), masker.Mask(), 
+					dataShifter.Word(), indexDecoder.Out()[i], mMemory.OutLine());
 		cacheLineDataOuts[i] = cachelines[i].OutLine();
 		cacheHitCollector.Connect(i, cachelines[i].CacheHit());
 	}
@@ -157,7 +230,7 @@ void Cache<CACHE_SIZE_BYTES, CACHE_LINE_BITS, MAIN_MEMORY_BYTES>::Connect(const 
 		dataWordBundles[i] = outCacheLineMux.Out().Range<WORD_SIZE>(i*WORD_SIZE);
 	}
 
-	outDataMux.Connect(dataWordBundles, offset);
+	outDataMux.Connect(dataWordBundles, address.WordOffsetInLine());
 }
 
 template <unsigned int CACHE_SIZE_BYTES, unsigned int CACHE_LINE_BITS, unsigned int MAIN_MEMORY_BYTES>
@@ -167,10 +240,8 @@ void Cache<CACHE_SIZE_BYTES, CACHE_LINE_BITS, MAIN_MEMORY_BYTES>::Update()
 	gotResultFromMemory.Update();
 	indexDecoder.Update();
 
-	bytemasker.Update();
-	halfmasker.Update();
 	masker.Update();
-	dataByteShifter.Update();
+	dataShifter.Update();
 
 	for (auto& line : cachelines)
 	{

--- a/VCPU/Control/Bundle.h
+++ b/VCPU/Control/Bundle.h
@@ -34,6 +34,11 @@ public:
 	}
 
 	// Creates a const Bundle (of Wire::OFF and Wire::ON) representing a number
+	explicit Bundle(long long n)
+	{
+		InitNumber(n);
+	}
+
 	explicit Bundle(int n)
 	{
 		InitNumber(n);
@@ -45,7 +50,7 @@ public:
 		InitNumber(val);
 	}
 	
-	void InitNumber(int n)
+	void InitNumber(long long n)
 	{
 		bool negative = n < 0;
 		n = abs(n) - (int)negative;
@@ -172,6 +177,18 @@ public:
 	{
 		int val = Read();
 		return val >= 0 ? val : pow2(N) + val;
+	}
+
+	long long ReadLong() const
+	{
+		long long n = 0;
+		bool negative = Get(N - 1).On();
+		for (int i = N - 2; i >= 0; --i)
+		{
+			n *= 2;
+			n += (negative ^ Get(i).On()) ? 1 : 0;
+		}
+		return (negative ? -1 : 1) * n - (int)negative;
 	}
 
 	template <unsigned int N>

--- a/VCPU/Functional/Masker.h
+++ b/VCPU/Functional/Masker.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <array>
+#include "Component.h"
+#include "Bundle.h"
+#include "Multiplexer.h"
+
+// Masker applies the mask to the "maskee", and then stomps the mask bits of base with maskee
+// Maskee 10101010101010101010101010101010
+// Mask   00000011111111000000111111110000
+// Base   11111111111111110000000000000000
+// Result 11111110101010110000101010100000
+
+template <unsigned int N>
+class Masker : public Component
+{
+public:
+	typedef Bundle<N> Word;
+	Masker();
+	void Connect(const Word& maskee, const Word& base, const Word& mask);
+	void Update();
+	const Word& Out() const { return out; }
+	
+private:
+	std::array<Multiplexer<2>, N> muxes;
+	Word out;
+};
+
+template<unsigned int N>
+inline Masker<N>::Masker()
+{
+	for (int i = 0; i < N; i++)
+	{
+		out.Connect(i, muxes[i].Out());
+	}
+}
+
+template<unsigned int N>
+inline void Masker<N>::Connect(const Word& maskee, const Word& base, const Word& mask)
+{
+	for (int i = 0; i < N; i++)
+	{
+		muxes[i].Connect({ &base[i], &maskee[i] }, mask[i]);
+	}
+}
+
+template<unsigned int N>
+inline void Masker<N>::Update()
+{
+	for (int i = 0; i < N; i++)
+	{
+		muxes[i].Update();
+	}
+}

--- a/VCPU/Memory/CacheLine.h
+++ b/VCPU/Memory/CacheLine.h
@@ -16,7 +16,7 @@ public:
 	typedef Bundle<LINE_BITS> LineBundle;
 
 	CacheLine();
-	void Connect(Bundle<NTag> tagin, const OffsetBundle& offset, const WordBundle& writewordmask, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline);
+	void Connect(Bundle<NTag> tagin, const OffsetBundle& wordoffset, const WordBundle& writewordmask, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline);
 	void Update();
 
 	const LineBundle& OutLine() { return outLineBundle; }
@@ -47,11 +47,11 @@ inline CacheLine<N, Nwords, NTag>::CacheLine()
 }
 
 template<unsigned int N, unsigned int Nwords, unsigned int NTag>
-void CacheLine<N, Nwords, NTag>::Connect(Bundle<NTag> tagin, const OffsetBundle& offset, const WordBundle& writewordmask, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline)
+void CacheLine<N, Nwords, NTag>::Connect(Bundle<NTag> tagin, const OffsetBundle& wordoffset, const WordBundle& writewordmask, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline)
 {
 	tag.Connect(tagin, writeline);
 	tagMatcher.Connect(tag.Out(), tagin);
-	offsetDecoder.Connect(offset, Wire::ON);
+	offsetDecoder.Connect(wordoffset, Wire::ON);
 	wordwriteOr.Connect(offsetDecoder.Out(), Bundle<Nwords>(writeline));
 	writeBitmask.Connect(writewordmask, Bundle<N>(writeline));
 	for (int i = 0; i < Nwords; i++)

--- a/VCPU/Memory/CacheLine.h
+++ b/VCPU/Memory/CacheLine.h
@@ -26,6 +26,7 @@ public:
 private:
 	Register<NTag> tag;
 	Matcher<NTag> tagMatcher;
+	AndGate cacheHitEnabled;
 	Decoder<Nwords> offsetDecoder;
 	MultiGate<OrGate, Nwords> wordwriteOr;
 	MultiGate<AndGate, Nwords> writeEnable;
@@ -54,9 +55,10 @@ void CacheLine<N, Nwords, NTag>::Connect(Bundle<NTag> tagin, const OffsetBundle&
 {
 	tag.Connect(tagin, writeline);
 	tagMatcher.Connect(tag.Out(), tagin);
+	cacheHitEnabled.Connect(tagMatcher.Out(), enable);
 	offsetDecoder.Connect(wordoffset, Wire::ON);
 	wordwriteOr.Connect(offsetDecoder.Out(), Bundle<Nwords>(writeline));
-	writeEnable.Connect(wordwriteOr.Out(), Bundle<Nwords>(enable));
+	writeEnable.Connect(wordwriteOr.Out(), Bundle<Nwords>(cacheHitEnabled.Out()));
 	writeBitmask.Connect(writewordmask, Bundle<N>(writeline));
 	for (int i = 0; i < Nwords; i++)
 	{
@@ -70,6 +72,7 @@ inline void CacheLine<N, Nwords, NTag>::Update()
 {
 	tag.Update();
 	tagMatcher.Update();
+	cacheHitEnabled.Update();
 	offsetDecoder.Update();
 	wordwriteOr.Update();
 	writeEnable.Update();

--- a/VCPU/Memory/CacheLine.h
+++ b/VCPU/Memory/CacheLine.h
@@ -3,9 +3,6 @@
 #include "Component.h"
 #include "Bundle.h"
 #include "Register.h"
-#include "MultiGate.h"
-#include "Decoder.h"
-#include "XNorGate.h"
 #include "Matcher.h"
 
 template <unsigned int N, unsigned int Nwords, unsigned int NTag>
@@ -13,32 +10,22 @@ class CacheLine : public Component
 {
 public:
 	static const int LINE_BITS = N * Nwords;
-	static const int OFFSET_ADDR = bits(Nwords);
 	typedef Bundle<N> WordBundle;
 	typedef Bundle<LINE_BITS> LineBundle;
 
 	CacheLine();
-	void Connect(Bundle<NTag> tagin, Bundle<OFFSET_ADDR> offset, const Wire& writeword, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline);
+	void Connect(Bundle<NTag> tagin, const WordBundle& writewordmask, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline);
 	void Update();
 
 	const WordBundle& OutWord() { return outWordMux.Out(); }
 	const LineBundle& OutLine() { return outLineBundle; }
-	const Wire& CacheHit() { return cacheHit.Out(); }
+	const Wire& CacheHit() { return tagMatcher.Out(); }
 
 private:
-	OrGate writeOr;
 	Register<NTag> tag;
 	Matcher<NTag> tagMatcher;
-	DFlipFlop valid;
-	AndGate cacheHit;
-
-	AndGate writeWordAndHit;
-	OrGate writeAllow;
-	std::array<Register<N>, Nwords> words;
-	Decoder<Nwords> offsetDecoder;
+	std::array<RegisterMasked<N>, Nwords> words;
 	std::array<MuxBundle<N, 2>, Nwords> writeDataMux;
-	MultiGate<OrGate, Nwords> writeWordSelectOr;
-	MultiGate<AndGate, Nwords> writeWordEnableAnd;
 
 	LineBundle outLineBundle;
 #ifdef DEBUG
@@ -56,40 +43,22 @@ inline CacheLine<N, Nwords, NTag>::CacheLine()
 }
 
 template<unsigned int N, unsigned int Nwords, unsigned int NTag>
-void CacheLine<N, Nwords, NTag>::Connect(Bundle<NTag> tagin, Bundle<OFFSET_ADDR> offset, const Wire& writeword, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline)
+void CacheLine<N, Nwords, NTag>::Connect(Bundle<NTag> tagin, const WordBundle& writewordmask, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline)
 {
-	writeOr.Connect(writeword, writeline);
 	tag.Connect(tagin, writeline);
 	tagMatcher.Connect(tag.Out(), tagin);
-	valid.Connect(writeline, writeline);
-	cacheHit.Connect(tagMatcher.Out(), valid.Q());
-
-	writeWordAndHit.Connect(writeword, cacheHit.Out());
-	writeAllow.Connect(writeWordAndHit.Out(), writeline);
-	offsetDecoder.Connect(offset);
-	writeWordSelectOr.Connect(offsetDecoder.Out(), Bundle<Nwords>(writeline));
-	writeWordEnableAnd.Connect(writeWordSelectOr.Out(), Bundle<Nwords>(writeAllow.Out()));
 	for (int i = 0; i < Nwords; i++)
 	{
 		writeDataMux[i].Connect({ dataword, dataline.Range<N>(i*N) }, writeline);
-		words[i].Connect(writeDataMux[i].Out(), writeWordEnableAnd.Out()[i]);
+		words[i].Connect(writeDataMux[i].Out(), writewordmask.Out()[i]);
 	}	
 }
 
 template<unsigned int N, unsigned int Nwords, unsigned int NTag>
 inline void CacheLine<N, Nwords, NTag>::Update()
 {
-	writeOr.Update();
 	tag.Update();
 	tagMatcher.Update();
-	valid.Update();
-	cacheHit.Update();
-
-	writeWordAndHit.Update();
-	writeAllow.Update();
-	offsetDecoder.Update();
-	writeWordSelectOr.Update();
-	writeWordEnableAnd.Update();
 	for (int i = 0; i < Nwords; i++)
 	{
 		writeDataMux[i].Update();

--- a/VCPU/Memory/CacheLine.h
+++ b/VCPU/Memory/CacheLine.h
@@ -47,7 +47,8 @@ inline CacheLine<N, Nwords, NTag>::CacheLine()
 }
 
 template<unsigned int N, unsigned int Nwords, unsigned int NTag>
-void CacheLine<N, Nwords, NTag>::Connect(Bundle<NTag> tagin, const OffsetBundle& wordoffset, const WordBundle& writewordmask, const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline)
+void CacheLine<N, Nwords, NTag>::Connect(Bundle<NTag> tagin, const OffsetBundle& wordoffset, const WordBundle& writewordmask, 
+										const WordBundle& dataword, const Wire& writeline, const LineBundle& dataline)
 {
 	tag.Connect(tagin, writeline);
 	tagMatcher.Connect(tag.Out(), tagin);

--- a/VCPU/Memory/Memory.h
+++ b/VCPU/Memory/Memory.h
@@ -72,12 +72,12 @@ inline void Memory<N, CACHE_LINE_BITS, BYTES>::Connect(ReqBuffer& reqbuf)
 	addrRWMux.Connect({ pReqBuffer->OutWrite().Addr(), pReqBuffer->OutRead()}, servicedRead.Out());
 
 	auto wordAddr = addrRWMux.Out().Range<WORD_INDEX_LEN>(BYTE_INDEX_LEN);
-	addrDecoder.Connect(wordAddr);
+	addrDecoder.Connect(wordAddr, pReqBuffer->PoppedWrite());
 	
 	std::array<CacheLineBundle, NUM_LINES> lineOuts;
 	for (int i = 0; i < NUM_WORDS; ++i)
 	{
-		registers[i].Connect(pReqBuffer->OutWrite().Data(), pReqBuffer->PoppedWrite());
+		registers[i].Connect(pReqBuffer->OutWrite().Data(), addrDecoder.Out()[i]);
 		unsigned int cache_line = i / CACHELINE_WORDS;
 		unsigned int bit_line_offset = (i % CACHELINE_WORDS) * N;
 		lineOuts[cache_line].Connect(bit_line_offset, registers[i].Out());

--- a/VCPU/Memory/Memory.h
+++ b/VCPU/Memory/Memory.h
@@ -92,8 +92,8 @@ inline void Memory<N, CACHE_LINE_BITS, BYTES>::Connect(ReqBuffer& reqbuf)
 	auto cachelineAddr = addrRWMux.Out().Range<CACHELINE_INDEX_LEN>(CACHELINE_ADDR_BITS);
 	outMux.Connect(lineOuts, cachelineAddr);
 
-	outData.Connect(outMux, Wire::ON);
-	outServicedRead.Connect(servicedRead.Out(), Wire::ON);
+	outData.Connect(outMux.Out(), Wire::ON);
+	outServicedRead.Connect(Bundle<1>(servicedRead.Out()), Wire::ON);
 	outAddr.Connect(addrRWMux.Out(), Wire::ON);
 }
 

--- a/VCPU/Memory/Register.h
+++ b/VCPU/Memory/Register.h
@@ -1,3 +1,102 @@
+#pragma once
+
+#include "Component.h"
+#include "DFlipFlop.h"
+#include "DFlipFlopReset.h"
+#include "Bundle.h"
+#include "MultiGate.h"
+
+template <unsigned int N>
+class Register : public Component
+{
+public:
+	static const int N = N;
+	Register();
+	void Connect(const Bundle<N>& data, const Wire& load);
+	void Update();
+
+	const Bundle<N>& Out() const { return out; }
+
+private:
+	std::array<DFlipFlop, N> bits;
+	Bundle<N> out;
+};
+
+template<unsigned int N>
+inline Register<N>::Register()
+{
+	for (int i = 0; i < N; ++i)
+	{
+		out.Connect(i, bits[i].Q());
+	}
+}
+
+template<unsigned int N>
+inline void Register<N>::Update()
+{
+	for (int i = 0; i < N; ++i)
+	{
+		bits[i].Update();
+	}
+}
+
+template<unsigned int N>
+inline void Register<N>::Connect(const Bundle<N>& data, const Wire & load)
+{
+	for (int i = 0; i < N; ++i)
+	{
+		bits[i].Connect(data[i], load);
+	}
+}
+
+
+template <unsigned int N>
+class RegisterReset : public Component
+{
+public:
+	RegisterReset();
+	void Connect(const Bundle<N>& data, const Wire& load, const Wire& reset);
+	void Update();
+
+	const Bundle<N>& Out() const { return out; }
+
+private:
+	Inverter resetInv;
+	AndGate doLoad;
+	std::array<DFlipFlopReset, N> bits;
+	Bundle<N> out;
+};
+
+template<unsigned int N>
+inline RegisterReset<N>::RegisterReset()
+{
+	for (int i = 0; i < N; ++i)
+	{
+		out.Connect(i, bits[i].Q());
+	}
+}
+
+template<unsigned int N>
+inline void RegisterReset<N>::Update()
+{
+	resetInv.Update();
+	doLoad.Update();
+	for (int i = 0; i < N; ++i)
+	{
+		bits[i].Update();
+	}
+}
+
+template<unsigned int N>
+inline void RegisterReset<N>::Connect(const Bundle<N>& data, const Wire & load, const Wire& reset)
+{
+	resetInv.Connect(reset);
+	doLoad.Connect(load, resetInv.Out());
+	for (int i = 0; i < N; ++i)
+	{
+		bits[i].Connect(data[i], doLoad.Out(), reset);
+	}
+}
 
 template <unsigned int N>
 class RegisterMasked : public Component
@@ -10,7 +109,7 @@ public:
 	const Bundle<N>& Out() const { return out; }
 
 private:
-	std::array<DFlipFlopReset, N> bits;
+	std::array<DFlipFlop, N> bits;
 	MultiGate<AndGate, N> writemask;
 	Bundle<N> out;
 };
@@ -29,7 +128,7 @@ inline void RegisterMasked<N>::Connect(const Bundle<N>& data, const Bundle<N>& m
 	writemask.Connect(mask, Bundle<N>(enable));
 	for (int i = 0; i < N; ++i)
 	{
-		bits[i].Connect(data[i], mask[i]);
+		bits[i].Connect(data[i], writemask.Out()[i]);
 	}
 }
 

--- a/VCPU/Memory/Register.h
+++ b/VCPU/Memory/Register.h
@@ -1,114 +1,17 @@
-#pragma once
-
-#include "Component.h"
-#include "DFlipFlop.h"
-#include "DFlipFlopReset.h"
-#include "Bundle.h"
-
-template <unsigned int N>
-class Register : public Component
-{
-public:
-	static const int N = N;
-	Register();
-	void Connect(const Bundle<N>& data, const Wire& load);
-	void Update();
-
-	const Bundle<N>& Out() const { return out; }
-
-private:
-	std::array<DFlipFlop, N> bits;
-	Bundle<N> out;
-};
-
-template<unsigned int N>
-inline Register<N>::Register()
-{
-	for (int i = 0; i < N; ++i)
-	{
-		out.Connect(i, bits[i].Q());
-	}
-}
-
-template<unsigned int N>
-inline void Register<N>::Update()
-{
-	for (int i = 0; i < N; ++i)
-	{
-		bits[i].Update();
-	}
-}
-
-template<unsigned int N>
-inline void Register<N>::Connect(const Bundle<N>& data, const Wire & load)
-{
-	for (int i = 0; i < N; ++i)
-	{
-		bits[i].Connect(data[i], load);
-	}
-}
-
-
-template <unsigned int N>
-class RegisterReset : public Component
-{
-public:
-	RegisterReset();
-	void Connect(const Bundle<N>& data, const Wire& load, const Wire& reset);
-	void Update();
-
-	const Bundle<N>& Out() const { return out; }
-
-private:
-	Inverter resetInv;
-	AndGate doLoad;
-	std::array<DFlipFlopReset, N> bits;
-	Bundle<N> out;
-};
-
-template<unsigned int N>
-inline RegisterReset<N>::RegisterReset()
-{
-	for (int i = 0; i < N; ++i)
-	{
-		out.Connect(i, bits[i].Q());
-	}
-}
-
-template<unsigned int N>
-inline void RegisterReset<N>::Update()
-{
-	resetInv.Update();
-	doLoad.Update();
-	for (int i = 0; i < N; ++i)
-	{
-		bits[i].Update();
-	}
-}
-
-template<unsigned int N>
-inline void RegisterReset<N>::Connect(const Bundle<N>& data, const Wire & load, const Wire& reset)
-{
-	resetInv.Connect(reset);
-	doLoad.Connect(load, resetInv.Out());
-	for (int i = 0; i < N; ++i)
-	{
-		bits[i].Connect(data[i], doLoad.Out(), reset);
-	}
-}
 
 template <unsigned int N>
 class RegisterMasked : public Component
 {
 public:
 	RegisterMasked();
-	void Connect(const Bundle<N>& data, const Bundle<N>& mask);
+	void Connect(const Bundle<N>& data, const Bundle<N>& mask, const Wire& enable);
 	void Update();
 
 	const Bundle<N>& Out() const { return out; }
 
 private:
-	std::array<DFlipFlop, N> bits;
+	std::array<DFlipFlopReset, N> bits;
+	MultiGate<AndGate, N> writemask;
 	Bundle<N> out;
 };
 
@@ -120,21 +23,23 @@ inline RegisterMasked<N>::RegisterMasked()
 		out.Connect(i, bits[i].Q());
 	}
 }
+template<unsigned int N>
+inline void RegisterMasked<N>::Connect(const Bundle<N>& data, const Bundle<N>& mask, const Wire& enable)
+{
+	writemask.Connect(mask, Bundle<N>(enable));
+	for (int i = 0; i < N; ++i)
+	{
+		bits[i].Connect(data[i], mask[i]);
+	}
+}
+
 
 template<unsigned int N>
 inline void RegisterMasked<N>::Update()
 {
+	writemask.Update();
 	for (int i = 0; i < N; ++i)
 	{
 		bits[i].Update();
-	}
-}
-
-template<unsigned int N>
-inline void RegisterMasked<N>::Connect(const Bundle<N>& data, const Bundle<N>& mask)
-{
-	for (int i = 0; i < N; ++i)
-	{
-		bits[i].Connect(data[i], mask[i]);
 	}
 }

--- a/VCPU/Memory/Register.h
+++ b/VCPU/Memory/Register.h
@@ -96,3 +96,45 @@ inline void RegisterReset<N>::Connect(const Bundle<N>& data, const Wire & load, 
 		bits[i].Connect(data[i], doLoad.Out(), reset);
 	}
 }
+
+template <unsigned int N>
+class RegisterMasked : public Component
+{
+public:
+	RegisterMasked();
+	void Connect(const Bundle<N>& data, const Bundle<N>& mask);
+	void Update();
+
+	const Bundle<N>& Out() const { return out; }
+
+private:
+	std::array<DFlipFlop, N> bits;
+	Bundle<N> out;
+};
+
+template<unsigned int N>
+inline RegisterMasked<N>::RegisterMasked()
+{
+	for (int i = 0; i < N; ++i)
+	{
+		out.Connect(i, bits[i].Q());
+	}
+}
+
+template<unsigned int N>
+inline void RegisterMasked<N>::Update()
+{
+	for (int i = 0; i < N; ++i)
+	{
+		bits[i].Update();
+	}
+}
+
+template<unsigned int N>
+inline void RegisterMasked<N>::Connect(const Bundle<N>& data, const Bundle<N>& mask)
+{
+	for (int i = 0; i < N; ++i)
+	{
+		bits[i].Connect(data[i], mask[i]);
+	}
+}

--- a/VCPU/Memory/RegisterFile.h
+++ b/VCPU/Memory/RegisterFile.h
@@ -25,7 +25,6 @@ public:
 
 private:
 	Decoder<NReg> addrwDecoder;
-	MultiGate<AndGate, NReg> writeEnable;
 	std::array<Register<N>, NReg> registers; // Make space for R0
 
 	MuxBundle<N, NReg> out1Mux, out2Mux;
@@ -36,15 +35,14 @@ private:
 template<unsigned int N, unsigned int NReg>
 inline void RegisterFile<N, NReg>::Connect(const AddrBundle & addr1, const AddrBundle & addr2, const AddrBundle& addrw, const DataBundle & data, const Wire& write)
 {
-	addrwDecoder.Connect(addrw);
-	writeEnable.Connect(addrwDecoder.Out(), Bundle<NReg>(write));
+	addrwDecoder.Connect(addrw, write);
 
 	std::array<DataBundle, NReg> regOuts;
 	registers[0].Connect(DataBundle::OFF, Wire::OFF);
 	regOuts[0] = registers[0].Out();
 	for (int i = 1; i < NReg; ++i)
 	{
-		registers[i].Connect(data, writeEnable.Out()[i]);
+		registers[i].Connect(data, addrwDecoder.Out()[i]);
 		regOuts[i] = registers[i].Out();
 	}
 	out1Mux.Connect(regOuts, addr1);
@@ -55,7 +53,6 @@ template<unsigned int N, unsigned int NReg>
 inline void RegisterFile<N, NReg>::Update()
 {
 	addrwDecoder.Update();
-	writeEnable.Update();
 	for (auto& reg : registers)
 	{
 		reg.Update();

--- a/VCPU/Memory/RequestBuffer.h
+++ b/VCPU/Memory/RequestBuffer.h
@@ -68,8 +68,8 @@ inline void RequestBuffer<N, ADDR_LEN, Nreg, POP_EVERY>::Connect(const AddrBundl
 {
 	popCycleCounter.Connect();
 
-	popRead.Connect(popCycleCounter.Pulse(), writebuffer.Empty());
-	popWrite.Connect(popCycleCounter.Pulse(), writebuffer.NonEmpty());
+	popRead.Connect(popCycleCounter.Pulse(), readbuffer.NonEmpty());
+	popWrite.Connect(popCycleCounter.Pulse(), readbuffer.Empty());
 
 	writebuffer.Connect(WriteReqBundle(addr, data), popWrite.Out(), writereq);
 	readbuffer.Connect(addr, popRead.Out(), readreq);

--- a/VCPU/Memory/RequestBuffer.h
+++ b/VCPU/Memory/RequestBuffer.h
@@ -14,23 +14,12 @@ template <unsigned int N, unsigned int ADDR_LEN, unsigned int Nreg, unsigned int
 class RequestBuffer : Component
 {
 public:
-	static const int ACTION_LEN = 3;
-	static const int BUF_WIDTH = N + ADDR_LEN + ACTION_LEN;
+	static const int BUF_WIDTH = N + ADDR_LEN;
 	static const int REG_INDEX_BITS = bits(Nreg);
 	typedef Bundle<ADDR_LEN> AddrBundle;
 	typedef Bundle<N> DataBundle;
 	typedef Bundle<BUF_WIDTH> WriteBufBundle;
-	typedef Bundle<ACTION_LEN> ActionBundle;
-
-	class WriteReqType : public ActionBundle
-	{
-	public:
-		using ActionBundle::Bundle;
-		const Wire& Write() const { return Get(0); }
-		const Wire& WriteByte() const { return Get(1); }
-		const Wire& WriteHalf() const { return Get(2); }
-	};
-
+	
 	class WriteReqBundle : public WriteBufBundle
 	{
 	public:
@@ -38,20 +27,18 @@ public:
 		WriteReqBundle(const WriteBufBundle& other)
 			: Bundle<BUF_WIDTH>(other)
 		{}
-		WriteReqBundle(const AddrBundle& addr, const DataBundle& data, const ActionBundle& action)
+		WriteReqBundle(const AddrBundle& addr, const DataBundle& data)
 			: Bundle<BUF_WIDTH>()
 		{
 			Connect(0, addr);
 			Connect(AddrBundle::N, data);
-			Connect(AddrBundle::N + DataBundle::N, action);
 		}
 
 		const AddrBundle Addr() const { return Range<ADDR_LEN>(); }
 		const DataBundle Data() const { return Range<DataBundle::N>(ADDR_LEN); }
-		const WriteReqType Action() const { WriteReqType a; a.Connect(0, Range<ACTION_LEN>(ADDR_LEN + DataBundle::N)); return a; }
 	};
 
-	void Connect(const AddrBundle & addr, const DataBundle & data, const ActionBundle& action, const Wire& readreq);
+	void Connect(const AddrBundle & addr, const DataBundle & data, const Wire& writereq, const Wire& readreq);
 	void Update();
 	const WriteReqBundle OutWrite() { return writeOut.Out(); }
 	const AddrBundle& OutRead() { return readOut.Out(); }
@@ -65,9 +52,7 @@ public:
 private:
 	ClockFreqSwitcher<POP_EVERY> popCycleCounter;
 
-	OrGateN<ACTION_LEN> pushWrite;
 	AndGate popWrite;
-	AndGate pushRead;
 	AndGate popRead;
 	CircularBuffer<BUF_WIDTH, Nreg> writebuffer;
 	CircularBuffer<ADDR_LEN, 1> readbuffer;
@@ -79,17 +64,15 @@ private:
 };
 
 template <unsigned int N, unsigned int ADDR_LEN, unsigned int Nreg, unsigned int POP_EVERY>
-inline void RequestBuffer<N, ADDR_LEN, Nreg, POP_EVERY>::Connect(const AddrBundle & addr, const DataBundle & data, const ActionBundle& action, const Wire& readreq)
+inline void RequestBuffer<N, ADDR_LEN, Nreg, POP_EVERY>::Connect(const AddrBundle & addr, const DataBundle & data, const Wire& writereq, const Wire& readreq)
 {
 	popCycleCounter.Connect();
 
-	pushWrite.Connect(action);
-	pushRead.Connect(Wire::ON, readreq);
 	popRead.Connect(popCycleCounter.Pulse(), writebuffer.Empty());
 	popWrite.Connect(popCycleCounter.Pulse(), writebuffer.NonEmpty());
 
-	writebuffer.Connect(WriteReqBundle(addr, data, action), popWrite.Out(), pushWrite.Out());
-	readbuffer.Connect(addr, popRead.Out(), pushRead.Out());
+	writebuffer.Connect(WriteReqBundle(addr, data), popWrite.Out(), writereq);
+	readbuffer.Connect(addr, popRead.Out(), readreq);
 
 	writeOut.Connect(writebuffer.Out(), popWrite.Out(), popRead.Out());
 	readOut.Connect(readbuffer.Out(), popRead.Out(), popWrite.Out());
@@ -101,8 +84,6 @@ template <unsigned int N, unsigned int ADDR_LEN, unsigned int Nreg, unsigned int
 inline void RequestBuffer<N, ADDR_LEN, Nreg, POP_EVERY>::Update()
 {
 	popCycleCounter.Update();
-	pushWrite.Update();
-	pushRead.Update();
 	popWrite.Update();
 	popRead.Update();
 	 

--- a/VCPU/Tests/TestCpu.cpp
+++ b/VCPU/Tests/TestCpu.cpp
@@ -7,7 +7,7 @@
 #include "Instructions.h"
 #include "Tools/Debugger.h"
 #include "Tools/Assembler.h"
-
+ 
 bool TestOpcodeDecoder(Verbosity verbosity)
 {
 	int i = 0;
@@ -317,15 +317,15 @@ bool TestCacheLineMasker(Verbosity verbosity)
 	wh.Set(true);
 	wb.Set(false);
 	test.Update();
-	success &= TestState(i++, 0x6ead0000U, test.Word().UnsignedRead(), verbosity);
+	success &= TestState(i++, 0xbeef0000U, test.Word().UnsignedRead(), verbosity);
 	success &= TestState(i++, 0x01234567beefcdef, test.Line().ReadLong(), verbosity);
 
 	wh.Set(false);
 	ww.Set(false);
+	test.Update();
 	success &= TestState(i++, 0, test.Word().Read(), verbosity);
 	success &= TestState(i++, 0x0123456789abcdef, test.Line().ReadLong(), verbosity);
-
-	
+		
 	return success;
 }
 
@@ -346,14 +346,14 @@ bool TestCache(Verbosity verbosity)
 	for (int a = 0; a < 8; a++)
 	{
 		addr.Write(0 + 4 * a);
-		data.Write(100000000 + 1111111 * a);
+		data.Write(0x10000000 + 0x111111 * a);
 		test.UpdateUntilNoStall();
 	}
 
 	for (int a = 0; a < 8; ++a)
 	{
 		addr.Write(64 + 4*a );
-		data.Write(200000000 + 1111111 * a);
+		data.Write(0x20000000 + 0x222222 * a);
 		test.UpdateUntilNoStall();
 	}
 	write.Set(false);
@@ -365,13 +365,13 @@ bool TestCache(Verbosity verbosity)
 	success &= TestState(i++, 0, test.Out().Read(), verbosity);
 	test.UpdateUntilNoStall();
 	success &= TestState(i++, true, test.CacheHit().On(), verbosity);
-	success &= TestState(i++, 101111111, test.Out().Read(), verbosity);
+	success &= TestState(i++, 0x10111111, test.Out().Read(), verbosity);
 	for (int a = 1; a < 8; a++)
 	{
 		addr.Write(4*a);
 		test.UpdateUntilNoStall();
 		success &= TestState(i++, true, test.CacheHit().On(), verbosity);
-		success &= TestState(i++, 100000000 + 1111111 * a, test.Out().Read(), verbosity);
+		success &= TestState(i++, 0x10000000 + 0x111111 * a, test.Out().Read(), verbosity);
 	}
 	addr.Write(88);
 	test.Update();
@@ -382,7 +382,7 @@ bool TestCache(Verbosity verbosity)
 		addr.Write(64 + 4*a);
 		test.UpdateUntilNoStall();
 		success &= TestState(i++, true, test.CacheHit().On(), verbosity);
-		success &= TestState(i++, 200000000 + 1111111 * a, test.Out().Read(), verbosity);
+		success &= TestState(i++, 0x20000000 + 0x111111 * a, test.Out().Read(), verbosity);
 	}
 
 	data.Write(4444);

--- a/VCPU/Tests/TestHelpers.h
+++ b/VCPU/Tests/TestHelpers.h
@@ -57,7 +57,9 @@ bool TestState(int i, T val1, T val2, Verbosity verbosity)
 	if (verbosity == VERBOSE || (!pass))
 	{
 		if (std::is_same<T, long long>::value) std::cout << std::hex;
+		if (std::is_same<T, unsigned int>::value) std::cout << std::hex;
 		std::cout << i << ".\t" << (pass ? "PASS: " : "FAIL: ") << "Expecting " << val1 << ", got " << val2 << std::endl;
+		if (std::is_same<T, unsigned int>::value) std::cout << std::dec;
 		if (std::is_same<T, long long>::value) std::cout << std::dec;
 	}
 	return pass;

--- a/VCPU/Tests/TestHelpers.h
+++ b/VCPU/Tests/TestHelpers.h
@@ -56,7 +56,9 @@ bool TestState(int i, T val1, T val2, Verbosity verbosity)
 	bool pass = val1 == val2;
 	if (verbosity == VERBOSE || (!pass))
 	{
+		if (std::is_same<T, long long>::value) std::cout << std::hex;
 		std::cout << i << ".\t" << (pass ? "PASS: " : "FAIL: ") << "Expecting " << val1 << ", got " << val2 << std::endl;
+		if (std::is_same<T, long long>::value) std::cout << std::dec;
 	}
 	return pass;
 }

--- a/VCPU/Tests/Tests.h
+++ b/VCPU/Tests/Tests.h
@@ -1141,7 +1141,7 @@ bool TestCacheLine(Verbosity verbosity)
 	MagicBundle<16> writemask;
 	Wire writeline(false);
 
-	test.Connect(tag, offset, writemask, dataword, writeline, dataline);
+	test.Connect(tag, offset, writemask, dataword, writeline, dataline, Wire::ON);
 
 	dataline.Write(0x1122334455667788);
 	tag.Write(987);

--- a/VCPU/Tests/Tests.h
+++ b/VCPU/Tests/Tests.h
@@ -25,6 +25,7 @@
 #include "Encoder.h"
 #include "Matcher.h"
 #include "Shifter.h"
+#include "Masker.h"
 #include "Comparator.h"
 #include "MuxBundle.h"
 #include "SelectBundle.h"
@@ -1072,6 +1073,36 @@ bool TestRegisterFile(Verbosity verbosity)
 	return success;
 }
 
+bool TestMasker(Verbosity verbosity)
+{
+	int i = 0;
+	bool success = true;
+
+	Masker<32> test;
+	MagicBundle<32> maskee, base, mask;
+	test.Connect(maskee, base, mask);
+
+	maskee.Write(0x12345678);
+	base.Write(0xaaaaaaaaU);
+	mask.Write(0);
+	test.Update();
+	success &= TestState(i++, 0xaaaaaaaaU, test.Out().UnsignedRead(), verbosity);
+
+	mask.Write(0x00ffff00);
+	test.Update();
+	success &= TestState(i++, 0xaa3456aaU, test.Out().UnsignedRead(), verbosity);
+
+	mask.Write(0xff0000f0U);
+	test.Update();
+	success &= TestState(i++, 0x12aaaa7aU, test.Out().UnsignedRead(), verbosity);
+
+	mask.Write(0xffffffffU);
+	test.Update();
+	success &= TestState(i++, 0x12345678U, test.Out().UnsignedRead(), verbosity);
+
+	return success;
+}
+
 bool TestMultiplier(Verbosity verbosity)
 {
 	bool success = true;
@@ -1458,6 +1489,7 @@ bool RunAllTests()
 	RUN_AUTO_TEST(TestThreeWireComponent, TestMultiplexer8, FAIL_ONLY);
 	RUN_TEST(TestComparator, FAIL_ONLY);
 	RUN_TEST(TestShifter, FAIL_ONLY);
+	RUN_TEST(TestMasker, FAIL_ONLY);
 	RUN_AUTO_TEST(TestBundleComponent, TestMatcher, FAIL_ONLY);
 	RUN_AUTO_TEST(TestThreeWireComponent, TestDecoder4, FAIL_ONLY);
 	RUN_AUTO_TEST(TestBundleComponent, TestDecoder8, FAIL_ONLY);

--- a/VCPU/Tests/Tests.h
+++ b/VCPU/Tests/Tests.h
@@ -657,22 +657,22 @@ bool TestSelectBundle(Verbosity verbosity)
 	return success;
 }
 
-bool TestEncoder4(const Wire& a, const Wire& b)
+bool TestEncoder4(const Wire& a, const Wire& b, const Wire& c)
 {
 	Decoder<4> dec;
-	dec.Connect({ &a, &b });
+	dec.Connect({ &a, &b }, c);
 	Encoder<4> test;
 	test.Connect(dec.Out());
 	dec.Update();
 	test.Update();
-	return dec.Out().UnsignedRead() == 1 << test.Out().UnsignedRead();
+	return c.On() ? (dec.Out().UnsignedRead() == 1 << test.Out().UnsignedRead()) : (test.Out().Read() == 0);
 }
 
 
 bool TestEncoder8(const Wire& a, const Wire& b, const Wire& c)
 {
 	Decoder<8> dec;
-	dec.Connect({ &a, &b, &c });
+	dec.Connect({ &a, &b, &c }, Wire::ON);
 	Encoder<8> test;
 	test.Connect(dec.Out());
 	dec.Update();
@@ -781,18 +781,18 @@ bool TestShifter(Verbosity verbosity)
 	return success;
 }
 
-bool TestDecoder4(const Wire& a, const Wire& b)
+bool TestDecoder4(const Wire& a, const Wire& b, const Wire& c)
 {
 	Decoder<4> test;
-	test.Connect({ &a, &b });
+	test.Connect({ &a, &b }, c);
 	test.Update();
-	return test.Out().UnsignedRead() == pow2(Bundle<2>({ &a, &b }).UnsignedRead());
+	return c.On() ? (test.Out().UnsignedRead() == pow2(Bundle<2>({ &a, &b }).UnsignedRead())) : test.Out().Read() == 0;
 }
 
 bool TestDecoder8(const Bundle<3>& in)
 {
 	Decoder<8> test;
-	test.Connect(in);
+	test.Connect(in, Wire::ON);
 	test.Update();
 	return test.Out().UnsignedRead() == pow2(in.UnsignedRead());
 }
@@ -800,7 +800,7 @@ bool TestDecoder8(const Bundle<3>& in)
 bool TestDecoder32(const Bundle<5>& in)
 {
 	Decoder<32> test;
-	test.Connect(in);
+	test.Connect(in, Wire::ON);
 	test.Update();
 	return test.Out().UnsignedRead() == pow2(in.UnsignedRead());
 }
@@ -1107,16 +1107,14 @@ bool TestCacheLine(Verbosity verbosity)
 	MagicBundle<8> dataword;
 	MagicBundle<32> dataline;
 	MagicBundle<20> tag;
-	Wire writeword(false);
+	MagicBundle<8> writemask;
 	Wire writeline(false);
 
-	test.Connect(tag, offset, writeword, dataword, writeline, dataline);
-	test.Update();
-	success &= TestState(i++, false, test.CacheHit().On(), verbosity);
+	test.Connect(tag, offset, writemask, dataword, writeline, dataline);
 
 	dataline.Write(185999660);
 	tag.Write(987);
-	writeword.Set(false);
+	writemask.Write(0);
 	writeline.Set(true);
 	test.Update();
 	success &= TestState(i++, 185999660, test.OutLine().Read(), verbosity);
@@ -1134,7 +1132,7 @@ bool TestCacheLine(Verbosity verbosity)
 	success &= TestState(i++, true, test.CacheHit().On(), verbosity);
 
 	dataword.Write(1);
-	writeword.Set(true);
+	writemask.Write(0xff);
 	writeline.Set(false);
 	offset.Write(0U);
 	test.Update();
@@ -1336,14 +1334,14 @@ bool TestRequestBuffer(Verbosity verbosity)
 
 	MagicBundle<32> data;
 	MagicBundle<10> addr;
-	MagicBundle<3> write;
+	Wire write(false);	
 	Wire read(false);	
 
 	test.Connect(addr, data, write, read);
 
 	data.Write(11);
 	addr.Write(10);
-	write.Write(0);
+	write.Set(false);
 
 	test.Update();
 	success &= TestState(i++, false, test.WriteFull().On(), verbosity);
@@ -1351,7 +1349,7 @@ bool TestRequestBuffer(Verbosity verbosity)
 	success &= TestState(i++, false, test.PoppedWrite().On(), verbosity);
 	success &= TestState(i++, false, test.PoppedRead().On(), verbosity);
 
-	write.Write(1);
+	write.Set(true);
 	test.Update();
 	success &= TestState(i++, false, test.WriteFull().On(), verbosity);
 	success &= TestState(i++, false, test.ReadPending().On(), verbosity);
@@ -1366,7 +1364,7 @@ bool TestRequestBuffer(Verbosity verbosity)
 	success &= TestState(i++, false, test.PoppedWrite().On(), verbosity);
 	success &= TestState(i++, false, test.PoppedRead().On(), verbosity);
 
-	write.Write(0);
+	write.Set(false);
 	read.Set(true);
 	addr.Write(128);
 	data.Write(3333333);
@@ -1377,7 +1375,6 @@ bool TestRequestBuffer(Verbosity verbosity)
 	success &= TestState(i++, false, test.PoppedRead().On(), verbosity);
 	success &= TestState(i++, 11, test.OutWrite().Data().Read(), verbosity);
 	success &= TestState(i++, 10, test.OutWrite().Addr().Read(), verbosity);
-	success &= TestState(i++, 1, test.OutWrite().Action().Read(), verbosity);
 	success &= TestState(i++, 0, test.OutRead().Read(), verbosity);
 	
 	addr.Write(3);
@@ -1390,7 +1387,6 @@ bool TestRequestBuffer(Verbosity verbosity)
 		success &= TestState(i++, false, test.PoppedRead().On(), verbosity);
 		success &= TestState(i++, 11, test.OutWrite().Data().Read(), verbosity);
 		success &= TestState(i++, 10, test.OutWrite().Addr().Read(), verbosity);
-		success &= TestState(i++, 1, test.OutWrite().Action().Read(), verbosity);
 		success &= TestState(i++, 0, test.OutRead().Read(), verbosity);
 	}
 	test.Update();
@@ -1400,7 +1396,6 @@ bool TestRequestBuffer(Verbosity verbosity)
 	success &= TestState(i++, false, test.PoppedRead().On(), verbosity);
 	success &= TestState(i++, 2222, test.OutWrite().Data().Read(), verbosity);
 	success &= TestState(i++, 31, test.OutWrite().Addr().Read(), verbosity);
-	success &= TestState(i++, 1, test.OutWrite().Action().Read(), verbosity);
 	success &= TestState(i++, 0, test.OutRead().Read(), verbosity);
 	for (int wait = 0; wait < 3; wait++)
 	{
@@ -1411,7 +1406,6 @@ bool TestRequestBuffer(Verbosity verbosity)
 		success &= TestState(i++, false, test.PoppedRead().On(), verbosity);
 		success &= TestState(i++, 2222, test.OutWrite().Data().Read(), verbosity);
 		success &= TestState(i++, 31, test.OutWrite().Addr().Read(), verbosity);
-		success &= TestState(i++, 1, test.OutWrite().Action().Read(), verbosity);
 		success &= TestState(i++, 0, test.OutRead().Read(), verbosity);
 	}
 	test.Update();
@@ -1421,7 +1415,6 @@ bool TestRequestBuffer(Verbosity verbosity)
 	success &= TestState(i++, true, test.PoppedRead().On(), verbosity);
 	success &= TestState(i++, 0, test.OutWrite().Data().Read(), verbosity);
 	success &= TestState(i++, 0, test.OutWrite().Addr().Read(), verbosity);
-	success &= TestState(i++, 0, test.OutWrite().Action().Read(), verbosity);
 	success &= TestState(i++, 128, test.OutRead().Read(), verbosity);
 				
 	return success;
@@ -1430,48 +1423,49 @@ bool TestRequestBuffer(Verbosity verbosity)
 bool RunAllTests()
 {
 	bool success = true;
-	RUN_AUTO_TEST(TestOneWireComponent, TestInverter, SILENT);
-	RUN_AUTO_TEST(TestThreeWireComponent, TestInverter3, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestAndGate, SILENT);
-	RUN_AUTO_TEST(TestBundleComponent, TestAndGate4, SILENT);
-	RUN_AUTO_TEST(TestBundleComponent, TestOrGate4, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestNandGate, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestOrGate, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestNorGate, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestXorGate, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestXNorGate, SILENT);
-	RUN_TEST(TestMultiGate, SILENT);
-	RUN_TEST(TestMultiGateN, SILENT);
-	RUN_TEST(TestMultiGateNBitwise, SILENT);
-	RUN_TEST(TestSRLatch, SILENT);
-	RUN_TEST(TestJKFlipFlop, SILENT);
-	RUN_TEST(TestDFlipFlop, SILENT);
-	RUN_TEST(TestDFlipFlopReset, SILENT);
-	RUN_TEST(TestBundle, SILENT);
-	RUN_TEST(TestRegister, SILENT);
-	RUN_TEST(TestCounter, SILENT);
-	RUN_TEST(TestFreqSwitcher, SILENT);
-	RUN_AUTO_TEST(TestThreeWireComponent, TestFullAdder, SILENT);
-	RUN_AUTO_TEST(TestOneWireComponent, TestMultiplexer2, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestMultiplexer4, SILENT);
-	RUN_TEST(TestMuxBundle, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestEncoder4, SILENT);
-	RUN_AUTO_TEST(TestThreeWireComponent, TestEncoder8, SILENT);
-	RUN_TEST(TestSelectBundle, SILENT);
-	RUN_AUTO_TEST(TestThreeWireComponent, TestMultiplexer8, SILENT);
-	RUN_TEST(TestComparator, SILENT);
-	RUN_TEST(TestShifter, SILENT);
-	RUN_AUTO_TEST(TestBundleComponent, TestMatcher, SILENT);
-	RUN_AUTO_TEST(TestTwoWireComponent, TestDecoder4, SILENT);
-	RUN_AUTO_TEST(TestBundleComponent, TestDecoder8, SILENT);
-	RUN_AUTO_TEST(TestBundleComponent, TestDecoder32, SILENT);
-	RUN_TEST(TestALU, SILENT);
-	RUN_TEST(TestRegisterFile, SILENT);
-	RUN_TEST(TestCacheLine, SILENT);
-	RUN_TEST(TestMultiplier, SILENT);
-	RUN_TEST(TestCircularBuffer, SILENT);
-	RUN_TEST(TestCircularBuffer1, SILENT);
-	RUN_TEST(TestRequestBuffer, SILENT);
+
+	RUN_AUTO_TEST(TestOneWireComponent, TestInverter, FAIL_ONLY);
+	RUN_AUTO_TEST(TestThreeWireComponent, TestInverter3, FAIL_ONLY);
+	RUN_AUTO_TEST(TestTwoWireComponent, TestAndGate, FAIL_ONLY);
+	RUN_AUTO_TEST(TestBundleComponent, TestAndGate4, FAIL_ONLY);
+	RUN_AUTO_TEST(TestBundleComponent, TestOrGate4, FAIL_ONLY);
+	RUN_AUTO_TEST(TestTwoWireComponent, TestNandGate, FAIL_ONLY);
+	RUN_AUTO_TEST(TestTwoWireComponent, TestOrGate, FAIL_ONLY);
+	RUN_AUTO_TEST(TestTwoWireComponent, TestNorGate, FAIL_ONLY);
+	RUN_AUTO_TEST(TestTwoWireComponent, TestXorGate, FAIL_ONLY);
+	RUN_AUTO_TEST(TestTwoWireComponent, TestXNorGate, FAIL_ONLY);
+	RUN_TEST(TestMultiGate, FAIL_ONLY);
+	RUN_TEST(TestMultiGateN, FAIL_ONLY);
+	RUN_TEST(TestMultiGateNBitwise, FAIL_ONLY);
+	RUN_TEST(TestSRLatch, FAIL_ONLY);
+	RUN_TEST(TestJKFlipFlop, FAIL_ONLY);
+	RUN_TEST(TestDFlipFlop, FAIL_ONLY);
+	RUN_TEST(TestDFlipFlopReset, FAIL_ONLY);
+	RUN_TEST(TestBundle, FAIL_ONLY);
+	RUN_TEST(TestRegister, FAIL_ONLY);
+	RUN_TEST(TestCounter, FAIL_ONLY);
+	RUN_TEST(TestFreqSwitcher, FAIL_ONLY);
+	RUN_AUTO_TEST(TestThreeWireComponent, TestFullAdder, FAIL_ONLY);
+	RUN_AUTO_TEST(TestOneWireComponent, TestMultiplexer2, FAIL_ONLY);
+	RUN_AUTO_TEST(TestTwoWireComponent, TestMultiplexer4, FAIL_ONLY);
+	RUN_TEST(TestMuxBundle, FAIL_ONLY);
+	RUN_AUTO_TEST(TestThreeWireComponent, TestEncoder4, FAIL_ONLY);
+	RUN_AUTO_TEST(TestThreeWireComponent, TestEncoder8, FAIL_ONLY);
+	RUN_TEST(TestSelectBundle, FAIL_ONLY);
+	RUN_AUTO_TEST(TestThreeWireComponent, TestMultiplexer8, FAIL_ONLY);
+	RUN_TEST(TestComparator, FAIL_ONLY);
+	RUN_TEST(TestShifter, FAIL_ONLY);
+	RUN_AUTO_TEST(TestBundleComponent, TestMatcher, FAIL_ONLY);
+	RUN_AUTO_TEST(TestThreeWireComponent, TestDecoder4, FAIL_ONLY);
+	RUN_AUTO_TEST(TestBundleComponent, TestDecoder8, FAIL_ONLY);
+	RUN_AUTO_TEST(TestBundleComponent, TestDecoder32, FAIL_ONLY);
+	RUN_TEST(TestALU, FAIL_ONLY);
+	RUN_TEST(TestRegisterFile, FAIL_ONLY);
+	RUN_TEST(TestCacheLine, FAIL_ONLY);
+	RUN_TEST(TestMultiplier, FAIL_ONLY);
+	RUN_TEST(TestCircularBuffer, FAIL_ONLY);
+	RUN_TEST(TestCircularBuffer1, FAIL_ONLY);
+	RUN_TEST(TestRequestBuffer, FAIL_ONLY);
 	return success;
 }
 #endif

--- a/VCPU/Tools/MagicBundle.h
+++ b/VCPU/Tools/MagicBundle.h
@@ -42,7 +42,7 @@ public:
 		Write(n);
 	}
 
-	void Write(int n)
+	void Write(long long n)
 	{
 		value = n;
 		Bundle<N> b(n);
@@ -50,6 +50,11 @@ public:
 		{
 			magicwires[i].Set(b[i].On());
 		}
+	}
+
+	void Write(int n)
+	{
+		Write((long long)n);
 	}
 
 	void Write(unsigned int n)
@@ -60,5 +65,5 @@ public:
 
 private:
 	std::array<Wire, N> magicwires;
-	int value;
+	long long value;
 };

--- a/VCPU/VCPU.natvis
+++ b/VCPU/VCPU.natvis
@@ -84,15 +84,46 @@
   <Type Name="Multiplexer&lt;16&gt;">
     <DisplayString>{{out={muxOut.muxOut.smuxOut.orOut.out}}}</DisplayString>
   </Type>
+  <Type Name="Bundle&lt;2&gt;">
+    <DisplayString>
+      {{bits={(int)wires[0]->state}{(int)wires[1]->state}, val={(int)wires[0]->state + 2*(int)wires[1]->state,x}}}
+    </DisplayString>
+  </Type>
+  <Type Name="Bundle&lt;4&gt;">
+    <DisplayString>
+      {{bits={(int)wires[0]->state}{(int)wires[1]->state}{(int)wires[2]->state}{(int)wires[3]->state},val={(int)wires[0]->state + 2*(int)wires[1]->state + 4*(int)wires[2]->state + 8*(int)wires[3]->state}}}
+    </DisplayString>
+  </Type>
+  <Type Name="Bundle&lt;8&gt;">
+    <DisplayString>
+      {{bits={(int)wires[0]->state}{(int)wires[1]->state}{(int)wires[2]->state}{(int)wires[3]->state}{(int)wires[4]->state}{(int)wires[5]->state}{(int)wires[6]->state}{(int)wires[7]->state},
+  val={(int)wires[0]->state + 2*(int)wires[1]->state + 4*(int)wires[2]->state + 8*(int)wires[3]->state + 16*(int)wires[4]->state + 32*(int)wires[5]->state + 64*(int)wires[6]->state + 128*(int)wires[7]->state}}}</DisplayString>
+  </Type>
   <Type Name="Bundle&lt;*&gt;">
-    <DisplayString>{{bits={(int)wires[0]->state}{(int)wires[1]->state}{(int)wires[2]->state}{(int)wires[3]->state}{(int)wires[4]->state}{(int)wires[5]->state}{(int)wires[6]->state}{(int)wires[7]->state}}}</DisplayString>
+    <DisplayString>
+      {{bits={(int)wires[0]->state}{(int)wires[1]->state}{(int)wires[2]->state}{(int)wires[3]->state}{(int)wires[4]->state}{(int)wires[5]->state}{(int)wires[6]->state}{(int)wires[7]->state}
+  {(int)wires[8]->state}{(int)wires[9]->state}{(int)wires[10]->state}{(int)wires[11]->state}{(int)wires[12]->state}{(int)wires[13]->state}{(int)wires[14]->state}{(int)wires[15]->state}
+  {(int)wires[16]->state}{(int)wires[17]->state}{(int)wires[18]->state}{(int)wires[19]->state}{(int)wires[20]->state}{(int)wires[21]->state}{(int)wires[22]->state}{(int)wires[23]->state}
+  {(int)wires[24]->state}{(int)wires[25]->state}{(int)wires[26]->state}{(int)wires[27]->state}{(int)wires[28]->state}{(int)wires[29]->state}{(int)wires[30]->state}{(int)wires[31]->state}}}
+    </DisplayString>
   </Type>
   <Type Name="Bundle&lt;32&gt;">
     <DisplayString>
       {{bits={(int)wires[0]->state}{(int)wires[1]->state}{(int)wires[2]->state}{(int)wires[3]->state}{(int)wires[4]->state}{(int)wires[5]->state}{(int)wires[6]->state}{(int)wires[7]->state}
-{(int)wires[8]->state}{(int)wires[9]->state}{(int)wires[10]->state}{(int)wires[11]->state}{(int)wires[12]->state}{(int)wires[13]->state}{(int)wires[14]->state}{(int)wires[15]->state}
-{(int)wires[16]->state}{(int)wires[17]->state}{(int)wires[18]->state}{(int)wires[19]->state}{(int)wires[20]->state}{(int)wires[21]->state}{(int)wires[22]->state}{(int)wires[23]->state}
-{(int)wires[24]->state}{(int)wires[25]->state}{(int)wires[26]->state}{(int)wires[27]->state}{(int)wires[28]->state}{(int)wires[29]->state}{(int)wires[30]->state}{(int)wires[31]->state}}}
+  {(int)wires[8]->state}{(int)wires[9]->state}{(int)wires[10]->state}{(int)wires[11]->state}{(int)wires[12]->state}{(int)wires[13]->state}{(int)wires[14]->state}{(int)wires[15]->state}
+  {(int)wires[16]->state}{(int)wires[17]->state}{(int)wires[18]->state}{(int)wires[19]->state}{(int)wires[20]->state}{(int)wires[21]->state}{(int)wires[22]->state}{(int)wires[23]->state}
+  {(int)wires[24]->state}{(int)wires[25]->state}{(int)wires[26]->state}{(int)wires[27]->state}{(int)wires[28]->state}{(int)wires[29]->state}{(int)wires[30]->state}{(int)wires[31]->state},
+  val={1*(long long)wires[0]->state + 2*(long long)wires[1]->state + 4*(long long)wires[2]->state + 8*(long long)wires[3]->state + 16*(long long)wires[4]->state + 32*(long long)wires[5]->state + 64*(long long)wires[6]->state + 128*(long long)wires[7]->state + 256*(long long)wires[8]->state + 512*(long long)wires[9]->state + 1024*(long long)wires[10]->state + 2048*(long long)wires[11]->state + 4096*(long long)wires[12]->state + 8192*(long long)wires[13]->state + 16384*(long long)wires[14]->state + 32768*(long long)wires[15]->state + 65536*(long long)wires[16]->state + 131072*(long long)wires[17]->state + 262144*(long long)wires[18]->state + 524288*(long long)wires[19]->state + 1048576*(long long)wires[20]->state + 2097152*(long long)wires[21]->state + 4194304*(long long)wires[22]->state + 8388608*(long long)wires[23]->state + 16777216*(long long)wires[24]->state + 33554432*(long long)wires[25]->state + 67108864*(long long)wires[26]->state + 134217728*(long long)wires[27]->state + 268435456*(long long)wires[28]->state + 536870912*(long long)wires[29]->state + 1073741824*(long long)wires[30]->state + 2147483648*(long long)wires[31]->state,x}}}
+    </DisplayString>
+  </Type>
+  <Type Name="Bundle&lt;16&gt;">
+    <DisplayString>
+      {{bits={(int)wires[0]->state}{(int)wires[1]->state}{(int)wires[2]->state}{(int)wires[3]->state}{(int)wires[4]->state}{(int)wires[5]->state}{(int)wires[6]->state}{(int)wires[7]->state}
+{(int)wires[8]->state}{(int)wires[9]->state}{(int)wires[10]->state}{(int)wires[11]->state}{(int)wires[12]->state}{(int)wires[13]->state}{(int)wires[14]->state}{(int)wires[15]->state},
+   val={(int)wires[0]->state + 2*(int)wires[1]->state + 4*(int)wires[2]->state + 8*(int)wires[3]->state + 16*(int)wires[4]->state + 32*(int)wires[5]->state + 64*(int)wires[6]->state + 128*(int)wires[7]->state
++ 256*(int)wires[8]->state + 512*(int)wires[9]->state + 1024*(int)wires[10]->state + 2048*(int)wires[11]->state + 4096*(int)wires[12]->state + 
+8192*(int)wires[13]->state + 16384*(int)wires[14]->state + 32768*(int)wires[15]->state,x}
+      }}}
     </DisplayString>
   </Type>
 </AutoVisualizer>

--- a/VCPU/VCPU.natvis
+++ b/VCPU/VCPU.natvis
@@ -58,6 +58,16 @@
     {{{out}}}
   </DisplayString>
 </Type>
+<Type Name="Decoder&lt;*&gt;">
+  <DisplayString>
+    {{out={ands.out}}}
+  </DisplayString>
+</Type>
+<Type Name="MultiGate&lt;*,*&gt;">
+  <DisplayString>
+    {{out={out}}}
+  </DisplayString>
+</Type>
 <Type Name="RequestBuffer&lt;*,*,*,*&gt;">
   <DisplayString>
     {{Wfull={writebuffer.counters.queueFull.out.state}, popW={popWrite.out.state}, popR={popRead.out.state}}}
@@ -87,6 +97,9 @@
   </Type>
   <Type Name="Multiplexer&lt;16&gt;">
     <DisplayString>{{out={muxOut.muxOut.smuxOut.orOut.out}}}</DisplayString>
+  </Type>
+  <Type Name="MuxBundle&lt;*&gt;">
+    <DisplayString>{{out={out},sel={select}}}</DisplayString>
   </Type>
   <Type Name="Bundle&lt;2&gt;">
     <DisplayString>

--- a/VCPU/VCPU.natvis
+++ b/VCPU/VCPU.natvis
@@ -83,6 +83,21 @@
       {{enable={(int)enables[0].in2->state}, {out}}}
     </DisplayString>
   </Type>
+  <Type Name="AndGateN&lt;*&gt;">
+    <DisplayString>
+      {{out={ands[$T1-2].out.state}}}
+    </DisplayString>
+  </Type>
+  <Type Name="OrGateN&lt;*&gt;">
+    <DisplayString>
+      {{out={ors[$T1-2].out.state}}}
+    </DisplayString>
+  </Type>
+  <Type Name="Matcher&lt;*&gt;">
+    <DisplayString>
+      {{{equalAnd}}}
+    </DisplayString>
+  </Type>
   <Type Name="InverterN&lt;*&gt;">
     <DisplayString>{{out={out}}}</DisplayString>
   </Type>
@@ -93,7 +108,7 @@
     <DisplayString>{{out={muxOut.orOut.out}}}</DisplayString>
   </Type>
   <Type Name="Multiplexer&lt;8&gt;">
-    <DisplayString>{{out={muxOut.muxOut.orOut.out}}}</DisplayString>
+    <DisplayString>{{out={muxOut.orOut.out}}}</DisplayString>
   </Type>
   <Type Name="Multiplexer&lt;16&gt;">
     <DisplayString>{{out={muxOut.muxOut.smuxOut.orOut.out}}}</DisplayString>

--- a/VCPU/VCPU.natvis
+++ b/VCPU/VCPU.natvis
@@ -41,16 +41,28 @@
     <DisplayString>{{Z={wires[0]->state}, C={wires[1]->state}, O={wires[2]->state}, N={wires[3]->state}}}</DisplayString>
   </Type>
   <Type Name="Register&lt;8&gt;">
-    <DisplayString>{{load={(int)bits[0].nandD.and.in2->state}, bits=
-{(int)bits[0].nandR.inv.out.state}
-{(int)bits[1].nandR.inv.out.state}
-{(int)bits[2].nandR.inv.out.state}
-{(int)bits[3].nandR.inv.out.state}
-{(int)bits[4].nandR.inv.out.state}
-{(int)bits[5].nandR.inv.out.state}
-{(int)bits[6].nandR.inv.out.state}
-{(int)bits[7].nandR.inv.out.state}}}</DisplayString>
+    <DisplayString>{{load={(int)bits[0].nandD.and.in2->state}, bits={out}}}</DisplayString>
   </Type>
+<Type Name="Register&lt;*&gt;">
+  <DisplayString>
+    {{{out}}}
+  </DisplayString>
+</Type>
+<Type Name="RegisterMasked&lt;*&gt;">
+  <DisplayString>
+    {{{out}}}
+  </DisplayString>
+</Type>
+<Type Name="RegisterReset&lt;*&gt;">
+  <DisplayString>
+    {{{out}}}
+  </DisplayString>
+</Type>
+<Type Name="RequestBuffer&lt;*,*,*,*&gt;">
+  <DisplayString>
+    {{Wfull={writebuffer.counters.queueFull.out.state}, popW={popWrite.out.state}, popR={popRead.out.state}}}
+  </DisplayString>
+</Type>
   <Type Name="Counter&lt;1&gt;">
     <DisplayString>
       {{enable={(int)jInput.in2->state}, bit={(int)bit.latch.norr.inv.out.state}}}
@@ -58,15 +70,7 @@
   </Type>
   <Type Name="Counter&lt;*&gt;">
     <DisplayString>
-      {{enable={(int)enables[0].in2->state}, bits=
-{(int)bits[0].latch.norr.inv.out.state}
-{(int)bits[1].latch.norr.inv.out.state}
-{(int)bits[2].latch.norr.inv.out.state}
-{(int)bits[3].latch.norr.inv.out.state}
-{(int)bits[4].latch.norr.inv.out.state}
-{(int)bits[5].latch.norr.inv.out.state}
-{(int)bits[6].latch.norr.inv.out.state}
-{(int)bits[7].latch.norr.inv.out.state}}}
+      {{enable={(int)enables[0].in2->state}, {out}}}
     </DisplayString>
   </Type>
   <Type Name="InverterN&lt;*&gt;">

--- a/VCPU/VCPU.vcxproj
+++ b/VCPU/VCPU.vcxproj
@@ -175,6 +175,7 @@
     <ClInclude Include="Functional\ALU.h" />
     <ClInclude Include="Functional\Comparator.h" />
     <ClInclude Include="Functional\FullAdder.h" />
+    <ClInclude Include="Functional\Masker.h" />
     <ClInclude Include="Functional\Matcher.h" />
     <ClInclude Include="Functional\Multiplier.h" />
     <ClInclude Include="Functional\OverflowDetector.h" />

--- a/VCPU/VCPU.vcxproj.filters
+++ b/VCPU/VCPU.vcxproj.filters
@@ -269,5 +269,8 @@
     <ClInclude Include="Control\ThreadedComponent.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Functional\Masker.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Extensive refactor of the Cache/Memory system. It's still not working perfectly, but it is a significant improvement on the no-write-allocate system I had before. 

Downsides are an extra cycle stall on memory write misses, but the win is not having to do a read-stall on every read-after-write.